### PR TITLE
refactor: missionutils.Console 테스트 구조 수정

### DIFF
--- a/src/test/java/missionutils/ConsoleTest.java
+++ b/src/test/java/missionutils/ConsoleTest.java
@@ -1,8 +1,6 @@
 package missionutils;
 
 import camp.nextstep.edu.missionutils.Console;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -10,25 +8,15 @@ import org.mockito.Mockito;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConsoleTest {
-
-    MockedStatic<Console> staticConsole;
     final String INPUT = "input";
-
-    @BeforeEach
-    public void before() {
-        staticConsole = Mockito.mockStatic(Console.class);
-        staticConsole.when(Console::readLine)
-                .thenReturn(INPUT);
-    }
 
     @Test
     public void readLine() {
-        String input = Console.readLine();
-        assertThat(input).isEqualTo(INPUT);
-    }
-
-    @AfterEach
-    public void after() {
-        staticConsole.close();
+        try (MockedStatic<Console> staticConsole = Mockito.mockStatic(Console.class)) {
+            staticConsole.when(Console::readLine)
+                    .thenReturn(INPUT);
+            String input = Console.readLine();
+            assertThat(input).isEqualTo(INPUT);
+        }
     }
 }


### PR DESCRIPTION
```
미션 진행을 위해 제공 받은 missionutils.Console 클래스의 테스트 중 static method를 Moking 하는 방식 변경
 - try 문 내부로 Mocking 및 Assertion 로직을 위치시켜 각 테스트가 static 메소드를 mocking할 수 있는 환경 제공
```

* class
 * ConsoleTest.java